### PR TITLE
chore: add dev and build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ yarn
 
 ### Start the app in development mode (hot-code reloading, error reporting, etc.)
 ```bash
-quasar dev --debug -m electron
+yarn dev
 ```
 
 Also see in `doc`.
 
 ### Lint the files
 ```bash
-yarn run lint
+yarn lint
 ```
 
 ### Build the app for production
 ```bash
-quasar build -m electron
+yarn build
 ```
 
 ### Customize the configuration

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
   "license": "GPLv3",
   "repository": "git@github.com:exislow/kleinanzeigen-magic.git",
   "scripts": {
-    "lint": "eslint --ext .js,.vue ./",
-    "test": "echo \"No test specified\" && exit 0"
+    "dev": "quasar dev --debug -m electron",
+    "build": "quasar build -m electron",
+    "lint": "eslint --ext .js,.vue ./"
   },
   "dependencies": {
     "@quasar/extras": "^1.9.15",


### PR DESCRIPTION
This PR adds the `dev` and `build` command in the `package.json` so people can run `yarn dev` and `yarn build` instead of the quasar equivalent. This is a pure QoL feature.