### PR TITLE
fix(ipc): return empty array if ads are missing

### DIFF
--- a/src-electron/main-process/kleinanzeigen.js
+++ b/src-electron/main-process/kleinanzeigen.js
@@ -176,7 +176,7 @@ export class Kleinanzeigen {
 
     try {
       const content = await this._httpGetJsonContent(urlSuffix);
-      const ad = content.ad;
+      const ad = content.ad ?? [];
 
       return ad;
     } catch (e) {


### PR DESCRIPTION
Fixes an error when user has no ads running. See #7 